### PR TITLE
Upload build files from matrix in releases

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -325,7 +325,7 @@ jobs:
             --generate-notes \
             $extra_opts \
             $REF_NAME \
-            dist/*
+            dist/dist-packages-*/*
         env:
           REF_NAME: ${{ github.ref_name }}
           REPOSITORY: ${{ github.repository }}


### PR DESCRIPTION
The matrix build produces sub dirs for each target combination and puts built files inside.