### PR TITLE
Bump version to 0.3.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,7 +32,7 @@ dependencies = [
 
 [[package]]
 name = "frequenz-microgrid-component-graph-python-bindings"
-version = "0.3.0"
+version = "0.3.2"
 dependencies = [
  "frequenz-microgrid-component-graph",
  "pyo3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "frequenz-microgrid-component-graph-python-bindings"
-version = "0.3.0"
+version = "0.3.2"
 edition = "2024"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html


### PR DESCRIPTION
The publication of 0.3.1 to PyPI failed because I forgot to change the crate version before I pushed the tag.