### PR TITLE
Opt into FromPyObject derive for Clone pyclasses under PyO3 0.29

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -6,7 +6,7 @@
 
 ## Upgrading
 
-<!-- Here goes notes on how to upgrade from previous versions, including deprecations and what they should be replaced with -->
+- Bumped PyO3 to 0.29 to pull in the fix for RUSTSEC out-of-bounds read advisory GHSA-36hh-v3qg-5jq4 (`nth`/`nth_back` on list/tuple iterators).
 
 ## New Features
 

--- a/src/graph.rs
+++ b/src/graph.rs
@@ -16,7 +16,7 @@ use pyo3::{
     types::{PyAny, PySet, PyType},
 };
 
-#[pyclass(subclass)]
+#[pyclass(subclass, from_py_object)]
 #[derive(Clone, Default, Debug)]
 pub struct ComponentGraphConfig {
     config: cg::ComponentGraphConfig,
@@ -60,7 +60,7 @@ impl ComponentGraphConfig {
     }
 }
 
-#[pyclass(subclass)]
+#[pyclass(subclass, from_py_object)]
 #[derive(Clone, Default, Debug)]
 pub struct FormulaOverrides {
     overrides: cg::FormulaOverrides,


### PR DESCRIPTION
PyO3 0.29 (bumped in #89) deprecated the automatic `FromPyObject` derive for
`#[pyclass]` types that implement `Clone`, which `cargo clippy -D warnings`
now rejects.

## Changes

- Opt back into the derive on `ComponentGraphConfig` and `FormulaOverrides`
  with `#[pyclass(..., from_py_object)]` — both are extracted from Python by
  value, so the derive must remain. No behavior change.
- Note the 0.29 upgrade (which also carries the GHSA-36hh-v3qg-5jq4
  out-of-bounds read fix) under Upgrading in the release notes.
